### PR TITLE
Use Type::Params to do type checks.

### DIFF
--- a/t/01-basics.t
+++ b/t/01-basics.t
@@ -9,13 +9,13 @@ my %hash = $maybe->hello_hash( one => 'a', two => ['b'], three => { four => 'ahh
 is_deeply(\%hash, { one => 'a', two => ['b'], three => { four => 'ahh' }, four => 'd' });
 eval { $maybe->hello_hash };
 my $error = $@;
-like( $error, qr/^Undef did not pass type constraint/, "hello hash fails");
+like( $error, qr/^Missing required parameter/, "hello hash fails");
 
 my $hashref = $maybe->hello_hashref({ one => 'a', two => ['b'], three => { four => 'ahh' } });
 is_deeply($hashref, { one => 'a', two => ['b'], three => { four => 'ahh' }, four => 'd' });
 eval { $maybe->hello_hashref };
 my $errorh = $@;
-like( $error, qr/^Undef did not pass type constraint/, "hello hashref fails");
+like( $error, qr/^Missing required parameter/, "hello hashref fails");
 
 my @list = $maybe->a_list( 'a', ['b'], { four => 'ahh' } );
 is_deeply(\@list, [ 'a', ['b'], { four => 'ahh' } ]);

--- a/t/03-default_value.t
+++ b/t/03-default_value.t
@@ -59,7 +59,7 @@ is_deeply(\%list, { one => 'Hello World', two => 'Goodbye World', three=>  'ahhh
 
 eval { $maybe->hash };
 my $errors = $@;
-like( $errors, qr/Undef did not pass type constraint "Str"/, "a list fails");
+like( $errors, qr/Missing required parameter/, "a list fails");
 
 my $attr = One::Two::Three::Attributes->new();
 
@@ -68,7 +68,7 @@ is_deeply(\%attr_list, { one => 'Hello World', two => 'Goodbye World', three=>  
 
 eval { $attr->hash };
 my $errors = $@;
-like( $errors, qr/Undef did not pass type constraint "Str"/, "a list fails");
+like( $errors, qr/Missing required parameter/, "a list fails");
 
 done_testing();
 

--- a/t/04-returns.t
+++ b/t/04-returns.t
@@ -9,13 +9,13 @@ my %hash = $maybe->hello_hash( one => 'a', two => ['b'], three => { four => 'ahh
 is_deeply(\%hash, { one => 'a', two => ['b'], three => { four => 'ahh' }, four => 'd' });
 eval { $maybe->hello_hash };
 my $error = $@;
-like( $error, qr/^Undef did not pass type constraint/, "hello hash fails");
+like( $error, qr/^Missing required parameter/, "hello hash fails");
 
 my $hashref = $maybe->hello_hashref({ one => 'a', two => ['b'], three => { four => 'ahh' } });
 is_deeply($hashref, { one => 'a', two => ['b'], three => { four => 'ahh' }, four => 'd' });
 eval { $maybe->hello_hashref };
 my $errorh = $@;
-like( $error, qr/^Undef did not pass type constraint/, "hello hashref fails");
+like( $error, qr/^Missing required parameter/, "hello hashref fails");
 
 my @list = $maybe->a_list( 'a', ['b'], { four => 'ahh' } );
 is_deeply(\@list, [ 'a', ['b'], { four => 'ahh' } ]);

--- a/t/05-combined.t
+++ b/t/05-combined.t
@@ -59,6 +59,6 @@ is_deeply(\%over, {
 
 eval { $maybe->hash( three => 'cannot be set' ) };
 my $errors = $@;
-like( $errors, qr/Error in params - An illegal passed key - three/, "a list fails");
+like( $errors, qr/Unrecognized parameter: three/, "a list fails");
 
 done_testing();

--- a/t/06-extends.t
+++ b/t/06-extends.t
@@ -57,7 +57,7 @@ is_deeply(\%list, {
 
 eval { $maybe->hash };
 my $errors = $@;
-like( $errors, qr/Undef did not pass type constraint "Str"/, "a list fails");
+like( $errors, qr/Missing required parameter/, "a list fails");
 
 done_testing();
 

--- a/t/07-extends_does_it_get_complicated.t
+++ b/t/07-extends_does_it_get_complicated.t
@@ -205,12 +205,12 @@ is_deeply(\%list, {
 my $six = One::Two::Three::Six->new();
 eval { $six->hash( three => 'ahhhh' ) };
 my $errors = $@;
-like( $errors, qr/Error in params - An illegal passed key - four -/, "four is currently not a valid param");
+like( $errors, qr/Unrecognized parameter: four/, "four is currently not a valid param");
 
 my $seven = One::Two::Three::Seven->new();
 eval { $seven->hash( three => 'ahhhh' ) };
 my $errors = $@;
-like( $errors, qr/Error in params - An illegal passed key - four -/, "four is currently not a valid param");
+like( $errors, qr/Unrecognized parameter: four/, "four is currently not a valid param");
 
 my $eight = One::Two::Three::Eight->new();
 my %list8 = $eight->hash( three => 'ahhhh' );

--- a/t/09-moose.t
+++ b/t/09-moose.t
@@ -59,7 +59,7 @@ is_deeply(\%list, { one => 'Hello World', two => 'Goodbye World', three=>  'ahhh
 
 eval { $maybe->hash };
 my $errors = $@;
-like( $errors, qr/Undef did not pass type constraint "Str"/, "a list fails");
+like( $errors, qr/Missing required parameter/, "a list fails");
 
 my $attr = One::Two::Three::Attributes->new();
 
@@ -68,7 +68,7 @@ is_deeply(\%attr_list, { one => 'Hello World', two => 'Goodbye World', three=>  
 
 eval { $attr->hash };
 my $errors = $@;
-like( $errors, qr/Undef did not pass type constraint "Str"/, "a list fails");
+like( $errors, qr/Missing required parameter/, "a list fails");
 
 done_testing();
 


### PR DESCRIPTION
Type::Params allows you to compile type checks for a whole bunch of parameters into a single coderef, making them faster. Running the following benchmark script shows an approximate **100% speed-up**. That is, it doubles the speed at which you can call `$object->hello_world(%args)`.

https://gist.github.com/tobyink/1b7a0b4a8556af5222c6e81ed341cf0d

Minor compatibility concern: it changes the text of some error messages, as the error messages will be generated by Type::Params rather than MooX::ValidateSubs. That said, I feel the new error messages are probably more helpful.

Also note this is based on the current DEVELOPMENT version of Type::Tiny. If you accept this pull request, you might want to wait for me to release a STABLE version. (Planned in three weeks!)